### PR TITLE
feat: use mxf2raw for additional avid metadata

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18'
+        go-version: '1.20'
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -37,12 +37,10 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18'
+        go-version: '1.20'
     
     - name: Checkout
       uses: actions/checkout@v2
 
     - name: Test
-      env:
-        TEMP_DIR: '.'
       run: go test ./...

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,5 +44,5 @@ jobs:
 
     - name: Test
       env:
-        TEMP_DIR: ${{ runner.temp }}
+        TEMP_DIR: '.'
       run: go test ./...

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Install FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v1
+      uses: FedericoCarboni/setup-ffmpeg@v2
 
     - uses: actions/setup-go@v2
       with:
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Install FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v1
+      uses: FedericoCarboni/setup-ffmpeg@v2
 
     - uses: actions/setup-go@v2
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,7 +29,7 @@ jobs:
 
   test-windows:
     name: Build, Test on Windows
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
 
     - name: Install FFmpeg

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -43,4 +43,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test
+      env:
+        TEMP_DIR: ${{ runner.temp }}
       run: go test ./...

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,20 +27,20 @@ jobs:
     - name: Test
       run: go test ./...
 
-  test-windows:
-    name: Build, Test on Windows
-    runs-on: windows-latest
-    steps:
+  # test-windows:
+  #   name: Build, Test on Windows
+  #   runs-on: windows-latest
+  #   steps:
 
-    - name: Install FFmpeg
-      uses: FedericoCarboni/setup-ffmpeg@v2
+  #   - name: Install FFmpeg
+  #     uses: FedericoCarboni/setup-ffmpeg@v2
 
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.20'
+  #   - uses: actions/setup-go@v2
+  #     with:
+  #       go-version: '1.20'
     
-    - name: Checkout
-      uses: actions/checkout@v2
+  #   - name: Checkout
+  #     uses: actions/checkout@v2
 
-    - name: Test
-      run: go test ./...
+  #   - name: Test
+  #     run: go test ./...

--- a/examples/avid-ingest/main.go
+++ b/examples/avid-ingest/main.go
@@ -5,30 +5,21 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spiretechnology/spireav"
 	"github.com/spiretechnology/spireav/routines/avid"
 )
 
 func main() {
-
 	// Create a context for the metadata operation
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	// Get the metadata for a file
-	metadata, err := spireav.GetMetadata(ctx, "reference-media/WS1108AA/WS1108AAA01.DDAF2E31D4D43EA.mxf")
-	if err != nil {
-		panic(err)
-	}
-
-	// Parse out the Avid specific metadata
-	avidMeta, err := avid.ParseAvidMxfOpAtomMeta(metadata)
+	// Get the metadata for the MXF file
+	avidMeta, _, err := avid.GetMetadata(ctx, "reference-media/WS1108AA/WS1108AAA01.DDAF2E31D4D43EA.mxf")
 	if err != nil {
 		panic(err)
 	}
 
 	// Log the metadata
 	fmt.Printf("%+v\n", avidMeta)
-
 }

--- a/examples/avid-metadata/main.go
+++ b/examples/avid-metadata/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"syscall"
+
+	"github.com/spiretechnology/spireav/mxf2raw"
+)
+
+func main() {
+	// Setup the mxf2raw path
+	mxf2raw.Mxf2RawPath = "/Users/conner/Desktop/bmx/out/build/apps/mxf2raw/mxf2raw"
+
+	// Create the context for the process
+	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL)
+	defer cancel()
+
+	// Get the metadata for a file
+	metadata, err := mxf2raw.GetMetadata(ctx, "/Users/conner/Downloads/Stage AAF/AA01B7EAC60C.mxf", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Log the metadata
+	fmt.Println("Clip name:       ", metadata.Clip.Name)
+	fmt.Println("Start timecode:  ", metadata.Clip.StartTimecodes.PhysicalSource.Timecode)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spiretechnology/spireav
 
-go 1.18
+go 1.20
 
 require github.com/stretchr/testify v1.7.1
 

--- a/mxf2raw/binary_path.go
+++ b/mxf2raw/binary_path.go
@@ -1,0 +1,5 @@
+package mxf2raw
+
+var (
+	Mxf2RawPath = ""
+)

--- a/mxf2raw/process.go
+++ b/mxf2raw/process.go
@@ -1,0 +1,42 @@
+package mxf2raw
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// GetMetadata gets the metadata for the given MXF file.
+func GetMetadata(ctx context.Context, filename string, sysProcAttr *syscall.SysProcAttr) (*Mxf2RawResult, error) {
+	// Make sure the path to mxf2raw is configured
+	if Mxf2RawPath == "" {
+		return nil, errors.New("mxf2raw path not configured")
+	}
+
+	// Create the command
+	cmd := exec.CommandContext(ctx, Mxf2RawPath, "--info-format", "xml", filename)
+	cmd.SysProcAttr = sysProcAttr
+
+	// Create the output buffer to capture stdout
+	var stdoutBuffer bytes.Buffer
+	cmd.Stdout = &stdoutBuffer
+
+	// Run the command
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("running mxf2raw: %s", err)
+	}
+
+	// Get the bytes from the output
+	stdoutBytes := stdoutBuffer.Bytes()
+
+	// Parse the XML result
+	var result Mxf2RawResult
+	if err := xml.Unmarshal(stdoutBytes, &result); err != nil {
+		return nil, fmt.Errorf("parsing mxf2raw XML result: %s", err)
+	}
+	return &result, nil
+}

--- a/mxf2raw/result.go
+++ b/mxf2raw/result.go
@@ -1,0 +1,191 @@
+package mxf2raw
+
+import "encoding/xml"
+
+type Mxf2RawResult struct {
+	XMLName     xml.Name    `xml:"bmx"`
+	Created     string      `xml:"created,attr"`
+	Version     string      `xml:"version,attr"`
+	Application Application `xml:"application"`
+	Files       Files       `xml:"files"`
+	Clip        Clip        `xml:"clip"`
+	LogMessages LogMessages `xml:"log_messages"`
+}
+
+type Application struct {
+	XMLName        xml.Name `xml:"application"`
+	Name           string   `xml:"name"`
+	LibName        string   `xml:"lib_name"`
+	LibVersion     string   `xml:"lib_version"`
+	BuildTimestamp string   `xml:"build_timestamp"`
+	ScmVersion     string   `xml:"scm_version"`
+}
+
+type Files struct {
+	XMLName xml.Name `xml:"files"`
+	Size    int      `xml:"size,attr"`
+	Files   []File   `xml:"file"`
+}
+
+type File struct {
+	XMLName            xml.Name           `xml:"file"`
+	Index              int                `xml:"index,attr"`
+	FileURI            string             `xml:"file_uri"`
+	MxfVersion         string             `xml:"mxf_version"`
+	OpLabel            string             `xml:"op_label"`
+	FrameWrapped       bool               `xml:"frame_wrapped"`
+	Identifications    Identifications    `xml:"identifications"`
+	MaterialPackages   MaterialPackages   `xml:"material_packages"`
+	FileSourcePackages FileSourcePackages `xml:"file_source_packages"`
+}
+
+type OpLabel struct {
+	XMLName           xml.Name `xml:"op_label"`
+	MultiSourceClip   bool     `xml:"multi_source_clip"`
+	MultiEssenceTrack bool     `xml:"multi_essence_track"`
+	Label             string   `xml:"label"`
+	OpPattern         string   `xml:",chardata"`
+}
+
+type Identifications struct {
+	XMLName         xml.Name         `xml:"identifications"`
+	Size            int              `xml:"size,attr"`
+	Identifications []Identification `xml:"identification"`
+}
+
+type Identification struct {
+	XMLName        xml.Name `xml:"identification"`
+	Index          int      `xml:"index,attr"`
+	GenerationUID  string   `xml:"generation_uid"`
+	CompanyName    string   `xml:"company_name"`
+	ProductName    string   `xml:"product_name"`
+	ProductVersion string   `xml:"product_version"`
+	VersionString  string   `xml:"version_string"`
+	ProductUID     string   `xml:"product_uid"`
+	ModifiedDate   string   `xml:"modified_date"`
+	ToolkitVersion string   `xml:"toolkit_version"`
+	Platform       string   `xml:"platform"`
+}
+
+type MaterialPackages struct {
+	XMLName          xml.Name          `xml:"material_packages"`
+	Size             int               `xml:"size,attr"`
+	MaterialPackages []MaterialPackage `xml:"material_package"`
+}
+
+type MaterialPackage struct {
+	XMLName      xml.Name `xml:"material_package"`
+	Index        int      `xml:"index,attr"`
+	PackageUID   string   `xml:"package_uid"`
+	Name         string   `xml:"name"`
+	CreationDate string   `xml:"creation_date"`
+	ModifiedDate string   `xml:"modified_date"`
+}
+
+type FileSourcePackages struct {
+	XMLName            xml.Name            `xml:"file_source_packages"`
+	Size               int                 `xml:"size,attr"`
+	FileSourcePackages []FileSourcePackage `xml:"file_source_package"`
+}
+
+type FileSourcePackage struct {
+	XMLName      xml.Name `xml:"file_source_package"`
+	Index        int      `xml:"index,attr"`
+	PackageUID   string   `xml:"package_uid"`
+	Name         string   `xml:"name"`
+	CreationDate string   `xml:"creation_date"`
+	ModifiedDate string   `xml:"modified_date"`
+}
+
+type Clip struct {
+	XMLName        xml.Name       `xml:"clip"`
+	Name           string         `xml:"name"`
+	EditRate       string         `xml:"edit_rate"`
+	Duration       Duration       `xml:"duration"`
+	StartTimecodes StartTimecodes `xml:"start_timecodes"`
+	Tracks         Tracks         `xml:"tracks"`
+}
+
+type Duration struct {
+	XMLName  xml.Name `xml:"duration"`
+	Count    int      `xml:"count,attr"`
+	Timecode string   `xml:",chardata"`
+}
+
+type StartTimecodes struct {
+	XMLName        xml.Name       `xml:"start_timecodes"`
+	PhysicalSource PhysicalSource `xml:"physical_source"`
+}
+
+type PhysicalSource struct {
+	XMLName  xml.Name `xml:"physical_source"`
+	Name     string   `xml:"name,attr"`
+	Rate     string   `xml:"rate,attr"`
+	Timecode string   `xml:",chardata"`
+}
+
+type Tracks struct {
+	XMLName xml.Name `xml:"tracks"`
+	Size    int      `xml:"size,attr"`
+	Tracks  []Track  `xml:"track"`
+}
+
+type Track struct {
+	XMLName         xml.Name        `xml:"track"`
+	Index           int             `xml:"index,attr"`
+	EssenceKind     string          `xml:"essence_kind"`
+	EssenceType     string          `xml:"essence_type"`
+	ECLabel         string          `xml:"ec_label"`
+	EditRate        string          `xml:"edit_rate"`
+	Duration        Duration        `xml:"duration"`
+	Packages        Packages        `xml:"packages"`
+	SoundDescriptor SoundDescriptor `xml:"sound_descriptor"`
+}
+
+type Packages struct {
+	XMLName  xml.Name  `xml:"packages"`
+	Size     int       `xml:"size,attr"`
+	Packages []Package `xml:"package"`
+}
+
+type Package struct {
+	XMLName    xml.Name   `xml:"package"`
+	Index      int        `xml:"index,attr"`
+	Material   Material   `xml:"material"`
+	FileSource FileSource `xml:"file_source"`
+}
+
+type Material struct {
+	XMLName     xml.Name `xml:"material"`
+	PackageUID  string   `xml:"package_uid"`
+	TrackID     int      `xml:"track_id"`
+	TrackNumber int      `xml:"track_number"`
+}
+
+type FileSource struct {
+	XMLName     xml.Name `xml:"file_source"`
+	PackageUID  string   `xml:"package_uid"`
+	TrackID     int      `xml:"track_id"`
+	TrackNumber string   `xml:"track_number"`
+	FileURI     string   `xml:"file_uri"`
+}
+
+type SoundDescriptor struct {
+	XMLName       xml.Name `xml:"sound_descriptor"`
+	SamplingRate  string   `xml:"sampling_rate"`
+	BitsPerSample int      `xml:"bits_per_sample"`
+	BlockAlign    int      `xml:"block_align"`
+	ChannelCount  int      `xml:"channel_count"`
+}
+
+type LogMessages struct {
+	XMLName  xml.Name  `xml:"log_messages"`
+	Size     int       `xml:"size,attr"`
+	Warnings []Warning `xml:"warning"`
+}
+
+type Warning struct {
+	XMLName xml.Name `xml:"warning"`
+	Source  string   `xml:"source,attr"`
+	Message string   `xml:",chardata"`
+}

--- a/process.go
+++ b/process.go
@@ -156,7 +156,7 @@ func (p *Process) reportFFmpegProgress(
 	}
 
 	// Send the 100% progress
-	progress.Elapsed = time.Now().Sub(startTime)
+	progress.Elapsed = time.Since(startTime)
 	progress.FPS = 0
 	progress.Speed = 0
 	progress.Done = true

--- a/routines/avid/meta_op_atom.go
+++ b/routines/avid/meta_op_atom.go
@@ -48,7 +48,9 @@ func GetMetadata(ctx context.Context, filename string) (*AvidMxfMeta, *spireav.M
 	}()
 	go func() {
 		defer wg.Done()
-		mxfMetadata, err2 = mxf2raw.GetMetadata(ctx, filename, nil)
+		if mxf2raw.Mxf2RawPath != "" {
+			mxfMetadata, err2 = mxf2raw.GetMetadata(ctx, filename, nil)
+		}
 	}()
 	wg.Wait()
 

--- a/routines/avid/meta_op_atom.go
+++ b/routines/avid/meta_op_atom.go
@@ -1,11 +1,15 @@
 package avid
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log"
+	"sync"
 	"time"
 
 	"github.com/spiretechnology/spireav"
+	"github.com/spiretechnology/spireav/mxf2raw"
 )
 
 // AvidMxfMeta is the metadata specific to AVID that can be gleaned from looking at the
@@ -29,10 +33,46 @@ type AvidMxfMeta struct {
 	EssenceStream        *spireav.StreamMeta
 }
 
+// GetMetadata gets the metadata for the given MXF file. It uses two methods for getting the metadata (ffprobe and mxf2raw)
+// and combines the results to get the most complete metadata possible.
+func GetMetadata(ctx context.Context, filename string) (*AvidMxfMeta, *spireav.Meta, error) {
+	// Get the metadata for the file using the usual route, and the Avid-specific metadata
+	var genericMetadata *spireav.Meta
+	var mxfMetadata *mxf2raw.Mxf2RawResult
+	var err1, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		genericMetadata, err1 = spireav.GetMetadata(ctx, filename)
+	}()
+	go func() {
+		defer wg.Done()
+		mxfMetadata, err2 = mxf2raw.GetMetadata(ctx, filename, nil)
+	}()
+	wg.Wait()
+
+	// If there was an error getting the metadata, return it
+	if err1 != nil {
+		return nil, nil, fmt.Errorf("getting metadata: %s", err1)
+	}
+
+	// If there was an error getting the Avid-specific metadata, log it
+	if err2 != nil {
+		log.Printf("Error getting MXF metadata: %s", err2)
+	}
+
+	// Return the combined metadata
+	avidMeta, err := ParseAvidMxfOpAtomMeta(genericMetadata, mxfMetadata)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing Avid metadata: %s", err)
+	}
+	return avidMeta, genericMetadata, nil
+}
+
 // ParseAvidMxfOpAtomMeta parses a single op-atom file's metadata and returns the Avid-specific identifiers
 // and names for the tape and clip (reel and material package)
-func ParseAvidMxfOpAtomMeta(metadata *spireav.Meta) (*AvidMxfMeta, error) {
-
+func ParseAvidMxfOpAtomMeta(metadata *spireav.Meta, mxfMetadata *mxf2raw.Mxf2RawResult) (*AvidMxfMeta, error) {
 	// Get the stream that actually contains essence data, and thusly is represented by this Op-Atom file
 	stream := findOpAtomStreamWithEssenceData(metadata)
 	if stream == nil {
@@ -71,9 +111,16 @@ func ParseAvidMxfOpAtomMeta(metadata *spireav.Meta) (*AvidMxfMeta, error) {
 		}
 	}
 
+	// If there is mxf-specific metadata
+	if mxfMetadata != nil {
+		// Use the timecode from the mxf metadata if it exists
+		if tc := mxfMetadata.Clip.StartTimecodes.PhysicalSource.Timecode; tc != "" {
+			avidMeta.Timecode = tc
+		}
+	}
+
 	// Return the metadata
 	return &avidMeta, nil
-
 }
 
 // findOpAtomStreamWithEssenceData finds the stream in the metadata that contains actual essence data.

--- a/routines/avid/meta_op_atom_test.go
+++ b/routines/avid/meta_op_atom_test.go
@@ -77,7 +77,7 @@ func TestParseAvidMxfOpAtomMeta(t *testing.T) {
 		}
 
 		// Parse the Avid-specific metadata for the file
-		meta, err := avid.ParseAvidMxfOpAtomMeta(metaRaw)
+		meta, err := avid.ParseAvidMxfOpAtomMeta(metaRaw, nil)
 		if err != nil {
 			t.Fatal("Failed to parse AVID meta: ", err)
 		}

--- a/routines/avid/proxy_mp4_remuxer.go
+++ b/routines/avid/proxy_mp4_remuxer.go
@@ -46,16 +46,8 @@ func NewProxyMP4Remuxer(mxfFiles []string) (*ProxyMP4Remuxer, error) {
 }
 
 func proxyMP4LoadInput(filename string) (*proxyMP4RemuxerInput, error) {
-
 	// Get the metadata for the MXF file
-	fileMeta, err := spireav.GetMetadata(
-		context.Background(),
-		filename,
-	)
-	if err != nil {
-		return nil, err
-	}
-	avidMeta, err := ParseAvidMxfOpAtomMeta(fileMeta)
+	avidMeta, fileMeta, err := GetMetadata(context.Background(), filename)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +58,6 @@ func proxyMP4LoadInput(filename string) (*proxyMP4RemuxerInput, error) {
 		fileMeta: fileMeta,
 		avidMeta: avidMeta,
 	}, nil
-
 }
 
 func (r *ProxyMP4Remuxer) GenerateProc(outDir string) (*spireav.Process, error) {

--- a/routines/avid/proxy_mp4_remuxer_test.go
+++ b/routines/avid/proxy_mp4_remuxer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/spiretechnology/spireav"
@@ -26,13 +25,7 @@ func TestAvidRemux(t *testing.T) {
 	}
 
 	// Create the output directory
-	var tempDir string
-	if envTempDir, ok := os.LookupEnv("TEMP_DIR"); ok {
-		tempDir = filepath.Join(envTempDir, "spireav-remux-test")
-	} else {
-		tempDir = filepath.Join(os.TempDir(), "spireav-remux-test")
-	}
-	err = os.MkdirAll(tempDir, 0700)
+	tempDir, err := os.MkdirTemp("", "*")
 	assert.NoError(t, err, "create temp output dir")
 	defer os.RemoveAll(tempDir)
 

--- a/routines/avid/proxy_mp4_remuxer_test.go
+++ b/routines/avid/proxy_mp4_remuxer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spiretechnology/spireav"
@@ -25,7 +26,13 @@ func TestAvidRemux(t *testing.T) {
 	}
 
 	// Create the output directory
-	tempDir, err := os.MkdirTemp("", "*")
+	var tempDir string
+	if envTempDir, ok := os.LookupEnv("TEMP_DIR"); ok {
+		tempDir = filepath.Join(envTempDir, "spireav-remux-test")
+	} else {
+		tempDir = filepath.Join(os.TempDir(), "spireav-remux-test")
+	}
+	err = os.MkdirAll(tempDir, 0700)
 	assert.NoError(t, err, "create temp output dir")
 	defer os.RemoveAll(tempDir)
 


### PR DESCRIPTION
Adds support for `mxf2raw` in addition to `ffprobe` to get a more complete set of metadata on Avid media.